### PR TITLE
Adds Exponential Marginal Cost Function

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -93,7 +93,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	if(k_elasticity!=0)
 		return round((cost/k_elasticity) * (1 - GLOB.E**(-1 * k_elasticity * amount)))	//anti-derivative of the marginal cost function
 	else
-		return round(cost * GLOB.E**(-1 * k_elasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
+		return round(cost * amount)	//alternative form derived from L'Hopital to avoid division by 0
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -60,7 +60,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
 	var/message = ""
 	var/cost = 100					// Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
-	var/kelasticity = 1/30				//coefficient used in marginal price calculation that roughly corresponds to price eleasticity
+	var/kelasticity = 1/30			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
 	var/contraband = FALSE			// Export must be unlocked with multitool.
 	var/emagged = FALSE				// Export must be unlocked with emag.
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -60,7 +60,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
 	var/message = ""
 	var/cost = 100					// Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
-	var/kelasticity = 1/30			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
+	var/k_elasticity = 1/30			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
 	var/contraband = FALSE			// Export must be unlocked with multitool.
 	var/emagged = FALSE				// Export must be unlocked with emag.
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
@@ -83,17 +83,17 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 /datum/export/process()
 	..()
-	cost *= GLOB.E**(kelasticity * (1/30))
+	cost *= GLOB.E**(k_elasticity * (1/30))
 	if(cost > init_cost)
 		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, contr = 0, emag = 0)
 	var/amount = get_amount(O, contr, emag)
-	if(kelasticity!=0)
-		return round((cost/kelasticity) * (1 - GLOB.E**(-1 * kelasticity * amount)))	//anti-derivative of the marginal cost function
+	if(k_elasticity!=0)
+		return round((cost/k_elasticity) * (1 - GLOB.E**(-1 * k_elasticity * amount)))	//anti-derivative of the marginal cost function
 	else
-		return round(cost * GLOB.E**(-1 * kelasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
+		return round(cost * GLOB.E**(-1 * k_elasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.
@@ -128,7 +128,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	else
 		total_amount += amount
 	
-	cost *= GLOB.E**(-1*kelasticity*amount)		//marginal cost modifier
+	cost *= GLOB.E**(-1*k_elasticity*amount)		//marginal cost modifier
 	SSblackbox.add_details("export_sold_amount","[O.type]|[amount]")
 	SSblackbox.add_details("export_sold_cost","[O.type]|[the_cost]")
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -123,7 +123,10 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/the_cost = get_cost(O)
 	var/amount = get_amount(O)
 	total_cost += the_cost
-	total_amount += amount
+	if(istype(O,/datum/export/material))
+		total_amount += amount*MINERAL_MATERIAL_AMOUNT
+	else
+		total_amount += amount
 	
 	cost *= GLOB.E**(-1*kelasticity*amount)		//marginal cost modifier
 	SSblackbox.add_details("export_sold_amount","[O.type]|[amount]")

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -60,6 +60,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
 	var/message = ""
 	var/cost = 100					// Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
+	var/kelasticity = 1/30				//coefficient used in marginal price calculation that roughly corresponds to price eleasticity
 	var/contraband = FALSE			// Export must be unlocked with multitool.
 	var/emagged = FALSE				// Export must be unlocked with emag.
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
@@ -82,14 +83,17 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 /datum/export/process()
 	..()
-	var/t = cost
-	cost += (t * 0.001)
+	cost *= GLOB.E**(kelasticity * (1/30))
 	if(cost > init_cost)
 		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, contr = 0, emag = 0)
-	return cost * get_amount(O, contr, emag)
+	var/amount = get_amount(O, contr, emag)
+	if(kelasticity!=0)
+		return round((cost/kelasticity) * (1 - GLOB.E**(-1 * kelasticity * amount)))	//anti-derivative of the marginal cost function
+	else
+		return round(cost * GLOB.E**(-1 * kelasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.
@@ -121,9 +125,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	total_cost += the_cost
 	total_amount += amount
 	
-	cost -= (the_cost * (0.01*amount))
-	if(cost < 1)
-		cost = 1
+	cost *= GLOB.E**(-1*kelasticity*amount)		//marginal cost modifier
 	SSblackbox.add_details("export_sold_amount","[O.type]|[amount]")
 	SSblackbox.add_details("export_sold_cost","[O.type]|[the_cost]")
 

--- a/code/modules/cargo/exports/intel.dm
+++ b/code/modules/cargo/exports/intel.dm
@@ -3,7 +3,7 @@
 // Selling Syndicate docs to NT
 /datum/export/intel
 	cost = 25000
-	kelasticity = 0
+	k_elasticity = 0
 	unit_name = "original article"
 	message = "of enemy intelligence"
 	var/global/originals_recieved = list()

--- a/code/modules/cargo/exports/intel.dm
+++ b/code/modules/cargo/exports/intel.dm
@@ -3,6 +3,7 @@
 // Selling Syndicate docs to NT
 /datum/export/intel
 	cost = 25000
+	kelasticity = 0
 	unit_name = "original article"
 	message = "of enemy intelligence"
 	var/global/originals_recieved = list()

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -3,7 +3,7 @@
 // Crates, boxes, lockers.
 /datum/export/large/crate
 	cost = 500
-	kelasticity = 0
+	k_elasticity = 0
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
 	exclude_types = list(/obj/structure/closet/crate/large)

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -3,6 +3,7 @@
 // Crates, boxes, lockers.
 /datum/export/large/crate
 	cost = 500
+	kelasticity = 0
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
 	exclude_types = list(/obj/structure/closet/crate/large)

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -2,7 +2,7 @@
 // +200 credits flat.
 /datum/export/manifest_correct
 	cost = 200
-	kelasticity = 0
+	k_elasticity = 0
 	unit_name = "approved manifest"
 	export_types = list(/obj/item/weapon/paper/manifest)
 
@@ -19,7 +19,7 @@
 // Refunds the package cost minus the cost of crate.
 /datum/export/manifest_error_denied
 	cost = -500
-	kelasticity = 0
+	k_elasticity = 0
 	unit_name = "correctly denied manifest"
 	export_types = list(/obj/item/weapon/paper/manifest)
 

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -2,6 +2,7 @@
 // +200 credits flat.
 /datum/export/manifest_correct
 	cost = 200
+	kelasticity = 0
 	unit_name = "approved manifest"
 	export_types = list(/obj/item/weapon/paper/manifest)
 
@@ -18,6 +19,7 @@
 // Refunds the package cost minus the cost of crate.
 /datum/export/manifest_error_denied
 	cost = -500
+	kelasticity = 0
 	unit_name = "correctly denied manifest"
 	export_types = list(/obj/item/weapon/paper/manifest)
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -25,14 +25,7 @@
 	else if(istype(I, /obj/item/weapon/ore))
 		amount *= 0.8 // Station's ore redemption equipment is really goddamn good.
 
-	return round(amount)
-
-/datum/export/material/get_cost(obj/O)
-	var/amount = get_amount(O)/MINERAL_MATERIAL_AMOUNT
-	if(kelasticity!=0)
-		return round((cost/kelasticity) * (1 - GLOB.E**(-1 * kelasticity * amount)))	//anti-derivative of the marginal cost function
-	else
-		return round(cost * GLOB.E**(-1 * kelasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
+	return round(amount/MINERAL_MATERIAL_AMOUNT)
 
 // Materials. Nothing but plasma is really worth selling. Better leave it all to RnD and sell some plasma instead.
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -28,7 +28,11 @@
 	return round(amount)
 
 /datum/export/material/get_cost(obj/O)
-	return round(..() / MINERAL_MATERIAL_AMOUNT)
+	var/amount = get_amount(O, contr, emag)/MINERAL_MATERIAL_AMOUNT
+	if(kelasticity!=0)
+		return round((cost/kelasticity) * (1 - GLOB.E**(-1 * kelasticity * amount)))	//anti-derivative of the marginal cost function
+	else
+		return round(cost * GLOB.E**(-1 * kelasticity * amount) * amount)	//alternative form derived from L'Hopital to avoid division by 0
 
 // Materials. Nothing but plasma is really worth selling. Better leave it all to RnD and sell some plasma instead.
 
@@ -47,6 +51,7 @@
 // Plasma. The oil of 26 century. The reason why you are here.
 /datum/export/material/plasma
 	cost = 500
+	kelasticity = 0
 	material_id = MAT_PLASMA
 	message = "cm3 of plasma"
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -44,7 +44,7 @@
 // Plasma. The oil of 26 century. The reason why you are here.
 /datum/export/material/plasma
 	cost = 500
-	kelasticity = 0
+	k_elasticity = 0
 	material_id = MAT_PLASMA
 	message = "cm3 of plasma"
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -28,7 +28,7 @@
 	return round(amount)
 
 /datum/export/material/get_cost(obj/O)
-	var/amount = get_amount(O, contr, emag)/MINERAL_MATERIAL_AMOUNT
+	var/amount = get_amount(O)/MINERAL_MATERIAL_AMOUNT
 	if(kelasticity!=0)
 		return round((cost/kelasticity) * (1 - GLOB.E**(-1 * kelasticity * amount)))	//anti-derivative of the marginal cost function
 	else

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -1,6 +1,6 @@
 /datum/export/seed
 	cost = 100 // Gets multiplied by potency
-	kelasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
+	k_elasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
 	var/needs_discovery = FALSE // Only for undiscovered species

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -1,6 +1,6 @@
 /datum/export/seed
 	cost = 100 // Gets multiplied by potency
-	kelasticity = 1	//high price elasticity, only need to export a few samples
+	kelasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
 	var/needs_discovery = FALSE // Only for undiscovered species

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -1,5 +1,6 @@
 /datum/export/seed
 	cost = 100 // Gets multiplied by potency
+	kelasticity = 1	//high price elasticity, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
 	var/needs_discovery = FALSE // Only for undiscovered species

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -111,10 +111,6 @@
 	unit_name = "cable piece"
 	export_types = list(/obj/item/stack/cable_coil)
 
-/datum/export/stack/cable/get_cost(O)
-	return round(..())
-
-
 // Weird Stuff
 
 // Alien Alloy. Like plasteel, but better.


### PR DESCRIPTION
MC = initial_cost * e^(-k * amount_sold)

Total cost of a group of items can be easily calculated from its antiderivative.

This is an improvement over the previous cost function which was a flat 1% decrease. In addition, the cost modification only applied after get_cost so cargo could easily bypass the cost decreases by loading all their exports in one go and sell everything at the initial cost. With the antiderivative get_cost this is now no longer the case. Selling the 20th item grouped with all the items now nets the same amount of points as selling the 20th item later in another shipment (barring the cost regain).