### PR TITLE
Onions can now be worn on the belt, which is the style of the time.

### DIFF
--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -24,6 +24,7 @@
 	icon_state = "onion"
 	tastes = list("onions" = 1)
 	wine_power = 30
+	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/food/grown/onion/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/onion_slice, 2, 15, screentip_verb = "Cut")


### PR DESCRIPTION
## About The Pull Request

Onions can now be worn on the belt, which is the style of the time.

## Why It's Good For The Game

We can't open pull requests like we used to. But we have our ways. One trick is to tell stories that don't go anywhere. Like the time I caught the shuttle to Baystation. I needed a new heel for my sneakers. So I decided to go to Baystation 12, which is what they called Baystation in those days. So I tied an onion to my belt, which was the style at the time. Now, to take the shuttle cost a credit, and in those days, credits had pictures of dollars on 'em. "Gimme five dollars for a credit," you'd say. Now where were we... oh yeah. The important thing was that I had an onion on my belt, which was the style at the time. They didn't have any white onions, because of the war. The only thing you could get was those big yellow ones...

## Changelog

:cl:
qol: We can't open pull requests like we used to. But we have our ways. One trick is to tell stories that don't go anywhere. Like the time I caught the shuttle to Baystation. I needed a new heel for my sneakers. So I decided to go to Baystation 12, which is what they called Baystation in those days. So I tied an onion to my belt, which was the style at the time. Now, to take the shuttle cost a credit, and in those days, credits had pictures of dollars on 'em. "Gimme five dollars for a credit," you'd say. Now where were we... oh yeah. The important thing was that I had an onion on my belt, which was the style at the time. They didn't have any white onions, because of the war. The only thing you could get was those big yellow ones...
/:cl:
